### PR TITLE
02282018 remove old bmc

### DIFF
--- a/geissonator/openbmc-events/openbmc-sfw
+++ b/geissonator/openbmc-events/openbmc-sfw
@@ -97,10 +97,10 @@ class BMC:
             self.reboot()
 
     def reboot(self):
-        r = self.session.post(
-            self.url + '/org/openbmc/control/bmc0/action/warmReset',
+        r = self.session.put(
+            self.url + '/xyz/openbmc_project/state/bmc0/attr/RequestedBMCTransition',
             headers={'Content-Type': 'application/json'},
-            data='{"data":[]}',
+            data='{"data": "xyz.openbmc_project.State.BMC.Transition.Reboot"}',
             verify=False)
 
         j = r.json()

--- a/leiyu/obmc-utils/upload_and_update.py
+++ b/leiyu/obmc-utils/upload_and_update.py
@@ -113,10 +113,10 @@ def getProgress(bmc):
 
 
 def reboot(bmc):
-    url = 'https://%s/org/openbmc/control/bmc0/action/warmReset' % bmc
-    cmds = ['curl', '-s', '-b', 'cjar', '-k', '-X', 'POST', '-H',
+    url = 'https://%s/xyz/openbmc_project/state/bmc0/attr/RequestedBMCTransition' % bmc
+    cmds = ['curl', '-s', '-b', 'cjar', '-k', '-X', 'PUT', '-H',
             'Content-Type: application/json', '-d',
-            '{"data": []}', url]
+            '{"data": "xyz.openbmc_project.State.BMC.Transition.Reboot"}', url]
     check_call(cmds, stdout=FNULL, stderr=FNULL)
 
 


### PR DESCRIPTION
https://gerrit.openbmc-project.xyz/#/c/9004/ will be removing support for the legacy bmc control object.  BMC reboots now go through the BMC phosphor state object.