### PR TITLE
python path not always the same

### DIFF
--- a/thalerj/openbmctool.py
+++ b/thalerj/openbmctool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
  Copyright 2017 IBM Corporation
 


### PR DESCRIPTION
On macos python3  default installation path is not /usr/bin. Adjusting launch path to allow for more accessibility
    
Signed-off-by: Chris Austen austenc@us.ibm.com