### PR TITLE
cla-signers: Update to latest IBM SchedA

### DIFF
--- a/emilyshaffer/cla-signers/cla-signers
+++ b/emilyshaffer/cla-signers/cla-signers
@@ -1,4 +1,4 @@
-Updated Tue May 15 08:29:55 EDT 2018
+Updated Thu May 31 11:18:12 EDT 2018
 Aditya Saripalli
 Adriana Kobylak
 Agustin Ortiz
@@ -50,6 +50,7 @@ Jayanth Othayoth
 Jayashankar Padath
 Jeremy Kerr
 Joel Stanley
+Joseph Reynolds
 Joy Onyerikwu
 Justin Thaler
 Kamil Majcher


### PR DESCRIPTION
Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>