### PR TITLE
Fix TypeError in fru status vebose output

### DIFF
--- a/thalerj/openbmctool.py
+++ b/thalerj/openbmctool.py
@@ -467,8 +467,8 @@ def fruStatus(host, args, session):
                 if hasSels:
                     loglist = []
                     faults = frulist[key+"/fault"]['endpoints']
-                    for key in faults:
-                        loglist.append(faults[key].split('/')[-1])
+                    for item in faults:
+                        loglist.append(item.split('/')[-1])
                     frus[fruName] = {"compName": fruName, "Functional": "No", "Present":boolToString(present), "IsFru": boolToString(isFru), "selList": ', '.join(loglist).strip() }
                 else:
                     frus[fruName] = {"compName": fruName, "Functional": "Yes", "Present":boolToString(present), "IsFru": boolToString(isFru), "selList": "None" }


### PR DESCRIPTION
It is a list, not a dictionary. 
Fixes: `TypeError: list indices must be integers, not unicode`

Now it's the same as in: https://github.com/openbmc/openbmc-tools/blob/4506e28dc44b5f60d6accac7135c77f8e8fff59c/thalerj/openbmctool.py#L453-L454

To reproduce run `openbmctool.py -H <host> -U <user> -P <password> fru status --verbose` with at least one fru component failure.